### PR TITLE
1.0.15: Update mesido for new licensing

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -130,7 +130,7 @@ lxml==4.9.3
     #   pyecore
 mccabe==0.7.0
     # via flake8
-mesido==0.1.3.1
+mesido==0.1.3.2
     # via
     #   -c requirements.txt
     #   omotes-grow-worker (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "python-dotenv ~= 1.0.0",
-    "mesido ~= 0.1.3.1",
+    "mesido ~= 0.1.3.2",
     "omotes-sdk-python ~= 0.0.16"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ kombu==5.3.4
     # via celery
 lxml==4.9.3
     # via pyecore
-mesido==0.1.3.1
+mesido==0.1.3.2
     # via omotes-grow-worker (pyproject.toml)
 msgpack==1.0.5
     # via influxdb


### PR DESCRIPTION
Update mesido from 0.1.3.1 to 0.1.3.2 (expect only licensing changes). Will land in omotes mvp.3